### PR TITLE
Feat/sync tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Simply tell me where you keep your templates, pass instructions through a tiny c
 
 Use me to:
 
-  - Generate boilerplate files (using a _really_ simple [templating language](https://www.npmjs.com/package/procurator)).
+- Generate boilerplate files (using a _really_ simple [templating language](https://www.npmjs.com/package/procurator)).
 - Alter existing files (like adding routes, or exports).
-- That's it. I don't do a lot, but I'm very good at what I do.
+- That's it. I don't do a lot (unless you teach me how), but I'm very good at what I do.
 
 ## Getting started
 
@@ -131,6 +131,8 @@ Out of the box you get the following parameters:
 
 Do you need more? Pass them along with the command as explained in the [The command](#the-command) chapter.
 
+Do you need to alter or manipulate parameters? Keep reading!
+
 ### Prepare
 
 It's also possible to manipulate your parameters before your task gets run, either for all the steps, or a specific one.
@@ -155,6 +157,8 @@ module.exports = {
 };
 ```
 
+_**Note: This also works for definedTasks. When used there, this automatically makes the task isolated.**_
+
 #### Complete task
 
 If you wish to manipulate the params for all steps following your prepare method, pass in a function as the task.
@@ -176,6 +180,31 @@ module.exports = {
 ```
 
 _**Note:** All steps that follow this prepare step will be affected, the ones before it will not._
+
+### Sync tasks
+
+Sometimes you want to create and edit files multiple times. One example is a redux/saga combo for API requests:
+
+```js
+module.exports = {
+  tasks: {
+    /* for the sake of brevity I'll omit the action and saga tasks from this example */ 
+    fullAction: [
+      { definedTask: 'action' },
+      { definedTask: 'saga' },
+    ],
+    
+    api: [
+      { definedTask: 'fullAction', sync: true },
+      { definedTask: 'fullAction', prepare: params => { params.type += 'Success'}, sync: true },
+      { definedTask: 'fullAction', prepare: params => { params.type += 'Failure'}, sync: true },
+    ],
+  }
+};
+```
+
+This would alter the same files three times, causing race conditions.
+By setting the sync flag, the steps will be executed in sequence, preventing race conditions from happening.
 
 ## defined tasks
 
@@ -208,6 +237,8 @@ By default, parameters are passed on to other tasks by reference.
 This means that changes made to the parameters by definedTasks are automatically passed on to the next task.
  
 You can disable this behavior by flagging a definedTask as `isolated`, meaning that parameter changes will only apply to that step.
+
+_**Note:** not needed when also using the `prepare` option._
 
 ```js
 module.exports = {

--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -5,7 +5,7 @@ const boards        = new Boards({ discovery: false });
 
 class Runner {
   constructor(config) {
-    this.boards = new Boards({discovery: false});
+    this.boards = new Boards({ discovery: false });
     this.config = config;
   }
 
@@ -20,16 +20,48 @@ class Runner {
       instructions = [instructions];
     }
 
-    return Promise.all(instructions.map(instruction => this.runTask(instruction, parameters)));
+    let previousTask = null;
+
+    return Promise.all(instructions.map(instruction => {
+      let runner;
+
+      if (previousTask) {
+        runner       = previousTask.then(() => this.runTask(instruction, parameters));
+        previousTask = null;
+      } else {
+        runner = this.runTask(instruction, parameters);
+      }
+
+      if (instruction.sync) {
+        previousTask = runner;
+      }
+
+      return runner;
+    }));
+  }
+
+  prepareParams(method, params) {
+    const preparedParams = method(params);
+
+    if (typeof preparedParams === 'object') {
+      return preparedParams;
+    }
+
+    return params;
   }
 
   runTask(instruction, parameters) {
+    // Prepare for step. Copy parameters to not affect other tasks.
+    if (typeof instruction.prepare === 'function') {
+      parameters = this.prepareParams(instruction.prepare, Homefront.merge({}, parameters));
+    }
+
     if (typeof instruction.definedTask !== 'undefined') {
       if (typeof instruction.definedTask !== 'string') {
         throw new Error(`definedTask must be a string. Got ${typeof instruction.definedTask}.`);
       }
 
-      if (instruction.isolated) {
+      if (instruction.isolated && typeof instruction.prepare !== 'function') {
         parameters = Homefront.merge({}, parameters);
       }
 
@@ -44,12 +76,7 @@ class Runner {
       throw new Error(`Invalid task "${instruction.task}" supplied`);
     }
 
-    if (typeof instruction.prepare === 'function') {
-      // Task-specific prepare, don't modify by reference.
-      parameters = instruction.prepare(Homefront.merge({}, parameters));
-    }
-
-    this[instruction.task](instruction, parameters);
+    return this[instruction.task](instruction, parameters);
   }
 
   modify(instruction, parameters) {
@@ -57,7 +84,7 @@ class Runner {
       sourceDirectory: this.config.appRoot,
       targetDirectory: this.config.appRoot,
       sourceFile     : this.getTarget(instruction.target, parameters),
-      modify         : {patch: instruction.patch}
+      modify         : { patch: instruction.patch }
     }));
   }
 


### PR DESCRIPTION
Sometimes you want to create and edit files multiple times. One example is a redux/saga combo for API requests:

```js
module.exports = {
  tasks: {
    /* for the sake of brevity I'll omit the action and saga tasks from this example */ 
    fullAction: [
      { definedTask: 'action' },
      { definedTask: 'saga' },
    ],
    
    api: [
      { definedTask: 'fullAction', sync: true },
      { definedTask: 'fullAction', prepare: params => { params.type += 'Success'}, sync: true },
      { definedTask: 'fullAction', prepare: params => { params.type += 'Failure'}, sync: true },
    ],
  }
};
```

This would alter the same files three times, causing race conditions.
This PR introduces the `sync` flag, which will cause the steps will be executed in sequence, preventing race conditions from happening.

Fixes #2 