### PR TITLE
Feat/dynamic task

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,42 @@ module.exports = {
 };
 ```
 
+## Dynamic tasks
+
+Dynamic tasks allow you to supply the tasks "JIT" and async!
+This is useful when you need to, for instance, read out a dir or make an API call before you know the tasks.
+
+Make an API call, read a dir, query a database or ask for user input on the CLI.
+This task type adds a ton of possibilities
+
+Here's an example to blow your proverbial mind:
+
+```js
+const fs = require('fs');
+
+module.exports = {
+  tasks: {
+    specialTask: {
+      dynamicTask: params => new Promise((resolve, reject) => {
+        fs.readdir(__dirname + '/src/components', (error, files) => {
+          if (error) {
+            return reject(error);
+          }
+
+          params.entries = files;
+
+          resolve({definedTask: 'logEntries'});
+        });
+      })
+    },
+
+    logEntries: {task: parameters => console.log('Logging entries!\n\n', parameters.entries)},
+  }
+};
+```
+
+Now you can run `boards specialTask`. Whaaaaaat!? I know.
+
 ## Templating
 
 Templating uses [Procurator](https://www.npmjs.com/package/procurator). This means you have some flexibility in terms of defaults and variables. Also, it's just extremely fast.

--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -10,10 +10,18 @@ class Runner {
   }
 
   run(task, parameters) {
-    let instructions = this.config.tasks[task];
+    let instructions = task;
+
+    if (typeof task === 'string') {
+      if (!this.config.tasks[task]) {
+        return Promise.reject(new Error(`Instructions for task "${task}" not found.`));
+      }
+
+      instructions = this.config.tasks[task];
+    }
 
     if (!instructions) {
-      throw new Error(`Instructions for task "${task}" not found.`);
+      return Promise.reject(new Error(`Invalid instructions provided.`));
     }
 
     if (!Array.isArray(instructions)) {
@@ -54,6 +62,13 @@ class Runner {
     // Prepare for step. Copy parameters to not affect other tasks.
     if (typeof instruction.prepare === 'function') {
       parameters = this.prepareParams(instruction.prepare, Homefront.merge({}, parameters));
+    }
+
+    // Allow dynamic tasks to be supplied.
+    if (typeof instruction.dynamicTask === 'function') {
+      return Promise.resolve(instruction.dynamicTask(parameters)).then(tasks => {
+        this.run(tasks, parameters);
+      });
     }
 
     if (typeof instruction.definedTask !== 'undefined') {


### PR DESCRIPTION
This PR adds support for `dynamicTask`. Dynamic tasks allow you to supply the tasks "JIT" and async! This is useful when you need to, for instance, read out a dir or make an API call before you know the tasks.

Make an API call, read a dir, query a database or ask for user input on the CLI.
This task type adds a ton of possibilities

Here's an example to blow your proverbial mind:

```js
const fs = require('fs');

module.exports = {
  tasks: {
    specialTask: {
      dynamicTask: params => new Promise((resolve, reject) => {
        fs.readdir(__dirname + '/src/components', (error, files) => {
          if (error) {
            return reject(error);
          }

          params.entries = files;

          resolve({definedTask: 'logEntries'});
        });
      })
    },

    logEntries: {task: parameters => console.log('Logging entries!\n\n', parameters.entries)},
  }
};
```

Now you can run `boards specialTask`. Whaaaaaat!? I know.

Fixes #3