### PR TITLE
feat(project): add support for presets

### DIFF
--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -1,23 +1,49 @@
-const { Boards }    = require('boards');
-const { Homefront } = require('homefront');
-const path          = require('path');
-const boards        = new Boards({ discovery: false });
+const {Boards}    = require('boards');
+const procurator  = require('procurator');
+const {Homefront} = require('homefront');
+const fileExists  = require('file-exists');
+const path        = require('path');
 
 class Runner {
   constructor(config) {
-    this.boards = new Boards({ discovery: false });
-    this.config = config;
+    this.config = Homefront.merge({tasks: {}}, config);
+    this.boards = new Boards({discoveryConfig: {prefix: 'boards-preset'}});
+  }
+
+  composeTask(task) {
+    if (this.config.tasks[task]) {
+      return this.config.tasks[task];
+    }
+
+    // Preset. Check if exists.
+    const parts      = task.split(':');
+    const presetName = parts.shift();
+    const presets    = this.boards.getPlugins();
+    const preset     = presets[presetName];
+    task             = parts[0];
+
+    if (!preset) {
+      throw new Error(`Preset "${presetName}" not found.`);
+    }
+
+    const presetTask = preset.tasks[task];
+
+    presetTask.fallbackSourceDirectory = preset.templateRoot;
+
+    return presetTask;
   }
 
   run(task, parameters) {
     let instructions = task;
 
+    parameters = Homefront.merge({}, this.config.parameters || {}, parameters);
+
     if (typeof task === 'string') {
-      if (!this.config.tasks[task]) {
+      instructions = this.composeTask(task);
+
+      if (!instructions) {
         return Promise.reject(new Error(`Instructions for task "${task}" not found.`));
       }
-
-      instructions = this.config.tasks[task];
     }
 
     if (!instructions) {
@@ -84,7 +110,7 @@ class Runner {
     }
 
     if (typeof instruction.task === 'function') {
-      return instruction.task(parameters, boards);
+      return instruction.task(parameters, this.boards);
     }
 
     if (typeof this[instruction.task] !== 'function') {
@@ -99,19 +125,38 @@ class Runner {
       sourceDirectory: this.config.appRoot,
       targetDirectory: this.config.appRoot,
       sourceFile     : this.getTarget(instruction.target, parameters),
-      modify         : { patch: instruction.patch }
+      modify         : {patch: instruction.patch}
     }));
   }
 
   generate(instruction, parameters) {
-    const parsed = path.parse(this.getTarget(instruction.target, parameters));
+    const parsed          = path.parse(this.getTarget(instruction.target, parameters));
+    const sourceDirectory = this.getTemplateDirectory(instruction);
 
     return boards.generate('TemplateGenerator', Object.assign({}, parameters, {
-      sourceFile     : instruction.template,
       targetFile     : parsed.base,
-      sourceDirectory: this.config.templateRoot,
-      targetDirectory: path.join(this.config.appRoot, parsed.dir)
+      targetDirectory: path.join(this.config.appRoot, parsed.dir),
+      sourceFile     : instruction.template,
+      sourceDirectory
     }));
+  }
+
+  getTemplateDirectory(instruction) {
+    if (fileExists.sync(path.resolve(this.config.templateRoot, instruction.template))) {
+      return this.config.templateRoot;
+    }
+
+    const fallback = instruction.fallbackSourceDirectory;
+
+    if (!fallback) {
+      throw new Error(`Template "${instruction.template}" not found.`);
+    }
+
+    if (!fileExists.sync(path.resolve(fallback, instruction.template))) {
+      throw new Error(`Preset template "${instruction.template}" not found.`);
+    }
+
+    return fallback;
   }
 
   getTarget(target, parameters) {
@@ -119,10 +164,7 @@ class Runner {
       return target(parameters);
     }
 
-    return target
-      .replace(/{{pascalCased}}/g, parameters.pascalCased)
-      .replace(/{{upperCased}}/g, parameters.upperCased)
-      .replace(/{{name}}/g, parameters.name);
+    return procurator.sync(target, parameters);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   "author": "RWOverdijk <wesley@spoonx.nl>",
   "license": "MIT",
   "dependencies": {
-    "boards": "^2.0.0",
+    "boards": "^3.1.1",
     "ezon": "^1.0.0",
-    "homefront": "^2.0.0"
+    "file-exists": "^5.0.1",
+    "homefront": "^2.0.0",
+    "procurator": "^2.1.0"
   },
   "devDependencies": {
     "conventional-changelog-cli": "^1.3.4"


### PR DESCRIPTION
Adds support for presets.

Example: https://github.com/SpoonX/boards-preset-aor


Example config for use with that preset:

```js
module.exports = {

  // Where is your application's source located?
  appRoot: __dirname + '/src',

  templateRoot: __dirname + '/templates',

  // Use app-wide parameters to configure presets.
  parameters: {
    foo: {
      bar: {
        bat: 'cake'
      }
    },
    greetings: 'salutations',
  },

  tasks: {
    // They can be overriden
    'aor:hello': {
      task: () => {
        console.log('not today');
      }
    }
  }
};
```

As to overriding templates, simply create a file in `templates/aor/hello.hs`.

**Update:**

All of this will be clearer once I create a more complete preset (skeleton, probably) with documentation.